### PR TITLE
#61 feature. Getting strategy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ node_modules/
 npm-debug.log
 yarn-error.log
 *.sublime*
+.idea

--- a/dist/enums/getting-strategy.js
+++ b/dist/enums/getting-strategy.js
@@ -1,0 +1,10 @@
+'use strict';
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+var GettingStrategy = exports.GettingStrategy = {
+  DEFAULT: 'default',
+  RETURN_PATH_BY_DEFAULT: 'return-path-by-default',
+  RETURN_PATH_BY_DEFAULT_WITHOUT_ERROR: 'return-path-by-default-without-error'
+};

--- a/dist/index.js
+++ b/dist/index.js
@@ -21,6 +21,7 @@ function _classCallCheck(instance, Constructor) { if (!(instance instanceof Cons
  * @property {Array} languages
  * @property {Boolean} [save]
  * @property {Function} [middleware]
+ * @property {String} [gettingStrategy]
  */
 
 /**  @type {VueMultiLanguageParams} */
@@ -28,7 +29,8 @@ var options = {
   initial: null,
   languages: [],
   save: false,
-  middleware: null
+  middleware: null,
+  gettingStrategy: ''
 
   /** @type {VueConstructor} */
 };var Vue = void 0;

--- a/dist/install.js
+++ b/dist/install.js
@@ -9,6 +9,8 @@ var _vue = require('vue');
 
 var _mixin = require('./mixin');
 
+var _gettingStrategy = require('./enums/getting-strategy');
+
 /**
  * @typedef {Object} VueMultiLanguageParams
  * @property {String} initial
@@ -23,21 +25,21 @@ var _mixin = require('./mixin');
  * @param {VueConstructor} _Vue
  * @param {VueMultiLanguageParams} options
  */
-// @ts-check
 var _install = exports._install = function _install(_Vue, options) {
   var initial = options.initial,
       languages = options.languages,
       save = options.save,
-      middleware = options.middleware;
+      middleware = options.middleware,
+      gettingStrategy = options.gettingStrategy;
 
 
   var mixin = (0, _mixin.register)(initial, languages, save || false, middleware || function (self, path) {
     return path;
-  });
+  }, gettingStrategy || _gettingStrategy.GettingStrategy.DEFAULT);
 
   // @ts-ignore
   if (mixin !== undefined) {
     // @ts-ignore
     _Vue.mixin(mixin);
   }
-};
+}; // @ts-check

--- a/dist/mixin.js
+++ b/dist/mixin.js
@@ -12,6 +12,8 @@ var _vue = require('vue');
 
 var _vue2 = _interopRequireDefault(_vue);
 
+var _gettingStrategy = require('./enums/getting-strategy');
+
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
 var EventBus = new _vue2.default();
@@ -21,14 +23,14 @@ var currentGlobal = null;
 var _with2 = null;
 /**
  * Register all plugin actions
- * 
+ *
  * @param {String} initial initial language
  * @param {Array} languages array with languages
  * @param {Boolean} save if save language in local storage
  * @param {Function} middleware function for handler get
+ * @param {String} gettingStrategy translation getting strategy
  */
-var register = exports.register = function register(initial, languages, save, middleware) {
-
+var register = exports.register = function register(initial, languages, save, middleware, gettingStrategy) {
   if (save) {
     var lang = window.localStorage.getItem('vueml-lang');
     if (lang === null) {
@@ -85,6 +87,8 @@ var register = exports.register = function register(initial, languages, save, mi
           return this;
         },
         get: function get(path) {
+          var initialPath = path;
+
           var current = languages.filter(function (l) {
             return l.name === currentGlobal;
           });
@@ -108,8 +112,14 @@ var register = exports.register = function register(initial, languages, save, mi
             if (ph in db) {
               db = db[ph];
             } else {
-              console.error('[vue-multilanguage] path \'' + path + '\' unknown from \'' + ph + '\'');
-              return db = false;
+              if (gettingStrategy !== _gettingStrategy.GettingStrategy.RETURN_PATH_BY_DEFAULT_WITHOUT_ERROR) {
+                console.error('[vue-multilanguage] path \'' + path + '\' unknown from \'' + ph + '\'');
+              }
+              if (gettingStrategy === _gettingStrategy.GettingStrategy.RETURN_PATH_BY_DEFAULT || gettingStrategy === _gettingStrategy.GettingStrategy.RETURN_PATH_BY_DEFAULT_WITHOUT_ERROR) {
+                db = initialPath;
+              } else {
+                return db = false;
+              }
             }
           });
 
@@ -127,6 +137,7 @@ var register = exports.register = function register(initial, languages, save, mi
               });
             }
             _with2 = null;
+
             return db;
           }
         },

--- a/example/src/ml.js
+++ b/example/src/ml.js
@@ -21,5 +21,6 @@ export default new MLCreate({
     // you can mutate path here
     // you should return path updated
     return path
-  }
+  },
+  gettingStrategy: 'default'
 })

--- a/src/enums/getting-strategy.js
+++ b/src/enums/getting-strategy.js
@@ -1,0 +1,5 @@
+export const GettingStrategy = {
+  DEFAULT: 'default',
+  RETURN_PATH_BY_DEFAULT: 'return-path-by-default',
+  RETURN_PATH_BY_DEFAULT_WITHOUT_ERROR: 'return-path-by-default-without-error'
+}

--- a/src/index.js
+++ b/src/index.js
@@ -8,6 +8,7 @@ import { _install } from './install'
  * @property {Array} languages
  * @property {Boolean} [save]
  * @property {Function} [middleware]
+ * @property {String} [gettingStrategy]
  */
 
 /**  @type {VueMultiLanguageParams} */
@@ -15,13 +16,14 @@ let options = {
   initial: null,
   languages: [],
   save: false,
-  middleware: null
+  middleware: null,
+  gettingStrategy: ''
 }
 
 /** @type {VueConstructor} */
 let Vue
 
-export const MLInstaller = 
+export const MLInstaller =
 /**
    * function for install plugin with Vue.use
    * @param {VueConstructor} _Vue Vue constructor
@@ -40,7 +42,7 @@ export class MLCreate {
     _install(Vue, options)
   }
 }
-  
+
 export class MLanguage {
   /**
    * Create new language

--- a/src/install.js
+++ b/src/install.js
@@ -1,6 +1,7 @@
 // @ts-check
 import { VueConstructor } from 'vue'
 import { register } from './mixin'
+import { GettingStrategy } from './enums/getting-strategy'
 
 /**
  * @typedef {Object} VueMultiLanguageParams
@@ -17,13 +18,14 @@ import { register } from './mixin'
  * @param {VueMultiLanguageParams} options
  */
 export const _install = (_Vue, options) => {
-  const { initial, languages, save, middleware } = options
+  const { initial, languages, save, middleware, gettingStrategy } = options
 
   const mixin = register(
     initial,
     languages,
     save || false,
-    middleware || ((self, path) => path)
+    middleware || ((self, path) => path),
+    gettingStrategy || GettingStrategy.DEFAULT
   )
 
 // @ts-ignore


### PR DESCRIPTION
https://github.com/leonardovilarinho/vue-multilanguage/issues/61

- Added optional option 'gettingStrategy' to the MLCreate constructor, that could can take one of the strategies:
default - by default, it works as is;
return-path-by-default - returns path by default and console.error exists;
return-path-by-default-without-error - returns path by default and console.error doesn't exist (it will be better to move this logic to a 'debug' option, that doesn't exist);